### PR TITLE
Fix typos in main.cpp and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Usage :
       - `--lxuid`: Get LxUID key for this distro
 
     clean
-     - Uninstalls the distro.
+      - Uninstall the distro.
 
     help
       - Print this usage message.
@@ -88,7 +88,6 @@ Usage :
 >{InstanceName}.exe
 [user@PC-NAME dir]$
 ```
-
 
 #### How to uninstall instance
 ```dos

--- a/main.cpp
+++ b/main.cpp
@@ -256,7 +256,7 @@ unsigned long QueryUser(wchar_t *TargetName,wchar_t *username)
     CreatePipe(&hIn, &hInTmp, &sa, 0);
     if(WslLaunch(TargetName,idcmd,0,hInTmp,hOutTmp,hOutTmp,&hProcess))
     {
-        fwprintf(stderr,L"ERROR:Failed to Excute id command.\n");
+        fwprintf(stderr,L"ERROR:Failed to execute id command.\n");
         return E_FAIL;
     }
     CloseHandle(hInTmp);
@@ -320,7 +320,7 @@ HRESULT RemoveDist(wchar_t *TargetName)
 
 void show_usage()
 {
-    wprintf(L"Useage :\n");
+    wprintf(L"Usage :\n");
     wprintf(L"    <no args>\n");
     wprintf(L"      - Launches the distro's default behavior. By default, this launches your default shell.\n\n");
     wprintf(L"    run <command line>\n");
@@ -336,7 +336,7 @@ void show_usage()
     wprintf(L"      - `--mount-drive`: Get on/off status of Mount drives\n");
     wprintf(L"      - `--lxuid`: Get LxUID key for this distro\n\n");
     wprintf(L"    clean\n");
-    wprintf(L"     - Uninstalls the distro.\n\n");
+    wprintf(L"      - Uninstall the distro.\n\n");
     wprintf(L"    help\n");
     wprintf(L"      - Print this usage message.\n\n");
     


### PR DESCRIPTION
Just fixes some minor typos maintaining much as the original text.

Two points to discuss:
1. Other than that I'd suggest replacing the text
`Launches the distro's default behavior. By default, this launches your default shell` 
by something simpler like
`Open a new shell with your default settings`

2. I am not native, so not sure if its better to use third singular person (with s) or not for the description. But at least I like to be consistent in the docs and use the same for all. wdyt we should do?