### PR TITLE
main.cpp: return HRESULT hr in RemoveDist

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -310,6 +310,7 @@ HRESULT RemoveDist(wchar_t *TargetName)
     {
         wprintf(L"Unregistering...\n");
         HRESULT hr = WslUnregisterDistribution(TargetName);
+        return hr;
     }
     else
     {


### PR DESCRIPTION
Remove the HRESULT from WslUnregisterDistribution in RemoveDist.
This will fix a compiling warning about control reaching end of non-void function.