### PR TITLE
Convert to plain C99

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,16 @@ compiler:
 addons:
   apt:
     packages:
-    - g++-mingw-w64-x86-64
+    - gcc-mingw-w64-x86-64
     - binutils-mingw-w64-x86-64
     - zip
 script:
 - '[ -z "$TRAVIS_TAG" ] || SW_VER=-DSW_VER=L\"$TRAVIS_TAG\"'
 - 'mkdir out zip'
-- 'x86_64-w64-mingw32-g++ --static main.cpp -o out/Launcher.exe $SW_VER'
+- 'x86_64-w64-mingw32-gcc -std=c99 --static main.c -o out/Launcher.exe $SW_VER'
 - 'find  ./res/* -maxdepth 1 -type d -printf ''%f\n'' > resl.txt'
 - 'xargs -a resl.txt -I{} x86_64-w64-mingw32-windres res/{}/res.rc -o res/{}.o'
-- 'xargs -a resl.txt -I{} x86_64-w64-mingw32-g++ --static main.cpp res/{}.o -o zip/{}.exe $SW_VER'
+- 'xargs -a resl.txt -I{} x86_64-w64-mingw32-gcc -std=c99 --static main.c res/{}.o -o zip/{}.exe $SW_VER'
 - 'cd zip'
 - 'zip ../out/icons.zip *'
 - 'cd ..'

--- a/main.c
+++ b/main.c
@@ -7,6 +7,7 @@
  */
 
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -88,7 +89,7 @@ int main()
 
         if(wargc == 1)
         {
-            WslInstallation wslInstallation = WslGetInstallationInfo(TargetName);
+            struct WslInstallation wslInstallation = WslGetInstallationInfo(TargetName);
             char buffer[MAX_BASEPATH_SIZE];
             wcstombs(buffer, wslInstallation.basePath, MAX_BASEPATH_SIZE);
             if (!dirExists(buffer))
@@ -200,7 +201,7 @@ int main()
                 }
                 else if(wcscmp(wargv[2],L"--lxuid") == 0)
                 {
-                    WslInstallation wsl = WslGetInstallationInfo(TargetName);
+                    struct WslInstallation wsl = WslGetInstallationInfo(TargetName);
                     if(wsl.uuid == NULL)
                     {
                         hr = E_FAIL;

--- a/wsld.h
+++ b/wsld.h
@@ -45,7 +45,7 @@ WSLLAUNCH WslLaunch;
 struct WslInstallation {
     wchar_t uuid[UUID_SIZE];
     wchar_t basePath[MAX_BASEPATH_SIZE];
-};
+} WslInstallation;
 
 void WslApiFree()
 {
@@ -82,8 +82,8 @@ int WslApiInit()
 return 0;
 }
 
-WslInstallation WslGetInstallationInfo(wchar_t *DistributionName) {
-    WslInstallation wslInstallation;
+struct WslInstallation WslGetInstallationInfo(wchar_t *DistributionName) {
+    struct WslInstallation wslInstallation;
 
     wchar_t RKey[]=L"Software\\Microsoft\\Windows\\CurrentVersion\\Lxss";
     HKEY hKey;


### PR DESCRIPTION
There seems to be no particular need to compile it as a C++ project. A
lightweight C99 toolchian can compile slimer binaries.

#### Build tools (excerpt from build logs):

Package `g++-mingw-w64-x86-64` vs. `gcc-mingw-w64-x86-64`.

###### Before
> Need to get 32.2 MB of archives.
> After this operation, 197 MB of additional disk space will be used.

###### After
> Need to get 25.3 MB of archives. **(21.43 % decrease)**
> After this operation, 165 MB of additional disk space will be used. **(16.24 % decrease)**

#### Produced binaries (size in bytes):

| Image name   | Before  | After  | % Decrease |
|--------------|---------|--------|------------|
| Alpine.exe   | 559929  | 263485 |   52.94    |
| Arch.exe     | 551737  | 255293 |   53.73    |
| Artix.exe    | 544569  | 248125 |   54.44    |
| CentOS.exe   | 550201  | 253757 |   53.88    |
| Debian.exe   | 554297  | 257853 |   53.48    |
| Fedora.exe   | 552249  | 255805 |   53.68    |
| Gentoo.exe   | 557369  | 260925 |   53.17    |
| openSUSE.exe | 552761  | 256317 |   53.63    |
| Ubuntu.exe   | 553785  | 257341 |   53.53    |
| Void.exe     | 582457  | 286013 |   50.89    |