### PR TITLE
Treat warning as error and fix a warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ addons:
 script:
 - '[ -z "$TRAVIS_TAG" ] || SW_VER=-DSW_VER=L\"$TRAVIS_TAG\"'
 - 'mkdir out zip'
-- 'x86_64-w64-mingw32-gcc -std=c99 --static main.c -o out/Launcher.exe $SW_VER'
+- 'x86_64-w64-mingw32-gcc -std=c99 --pedantic -Wall -Werror -Wno-implicit-function-declaration --static main.c -o out/Launcher.exe $SW_VER'
 - 'find  ./res/* -maxdepth 1 -type d -printf ''%f\n'' > resl.txt'
 - 'xargs -a resl.txt -I{} x86_64-w64-mingw32-windres res/{}/res.rc -o res/{}.o'
-- 'xargs -a resl.txt -I{} x86_64-w64-mingw32-gcc -std=c99 --static main.c res/{}.o -o zip/{}.exe $SW_VER'
+- 'xargs -a resl.txt -I{} x86_64-w64-mingw32-gcc -std=c99 --pedantic -Wall -Werror -Wno-implicit-function-declaration --static main.c res/{}.o -o zip/{}.exe $SW_VER'
 - 'cd zip'
 - 'zip ../out/icons.zip *'
 - 'cd ..'

--- a/wsld.h
+++ b/wsld.h
@@ -90,7 +90,7 @@ return 0;
 }
 
 struct WslInstallation WslGetInstallationInfo(wchar_t *DistributionName) {
-    struct WslInstallation wslInstallation = {.uuid = 0, .basePath = 0};
+    struct WslInstallation wslInstallation = {.uuid = {0}, .basePath = {0}};
 
     wchar_t RKey[]=L"Software\\Microsoft\\Windows\\CurrentVersion\\Lxss";
     HKEY hKey;


### PR DESCRIPTION
In case of msvc in `appveyor`, we are using `/WX` to treat warnings as error. This PR matches the strictness level in `.travis.yml` for gcc and fixes the following warnings:

```sh
wsld.h:95:12: error: missing braces around initializer [-Werror=missing-braces]
     struct WslInstallation wslInstallation = {.uuid = 0, .basePath = 0};
            ^
```

and explicitly ignores `Wimplicit-function-declaration` for `scanf_s`, `swscanf_s` etc.