### PR TITLE
Extend the maximum length of "run" commands

### DIFF
--- a/main.c
+++ b/main.c
@@ -7,6 +7,7 @@
  */
 
 
+#include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -113,7 +114,8 @@ int main()
         }
         else if( WARGV_CMP(1,L"run") | WARGV_CMP(1,L"-c") | WARGV_CMP(1,L"/c") )
         {
-            wchar_t rArgs[500] = L"";
+            wchar_t rArgs[SHRT_MAX] = L"";  // The total maximum length of a command line on Windows (at least Windows 10+)
+                                            // is SHRT_MAX characters (see: https://devblogs.microsoft.com/oldnewthing/20031210-00/?p=41553)
             int i;
             for (i=2;i<wargc;i++)
             {


### PR DESCRIPTION
This fixes running long commands with `distro.exe run <blah>`. One particular (ab)user of such commands is JetBrains IDEs. 

We can technically save a few bytes here by allocating `SHRT_MAX - length(" run ")`, but I feel like it's not worth the readability cost.