### PR TITLE
Don't inherit current directory when using wt/flute

### DIFF
--- a/main.c
+++ b/main.c
@@ -168,7 +168,7 @@ int main()
 
                         wcscat_s(Ecmd, ARRAY_LENGTH(Ecmd), L" \"");
                         wcscat_s(Ecmd, ARRAY_LENGTH(Ecmd), efpath);
-                        wcscat_s(Ecmd, ARRAY_LENGTH(Ecmd), L"\" run");
+                        wcscat_s(Ecmd, ARRAY_LENGTH(Ecmd), L"\"");
 
                         FreeConsole();
                         STARTUPINFOW si = {0};
@@ -187,7 +187,7 @@ int main()
 
                         wcscat_s(Ecmd, ARRAY_LENGTH(Ecmd), L" run \"");
                         wcscat_s(Ecmd, ARRAY_LENGTH(Ecmd), efpath);
-                        wcscat_s(Ecmd, ARRAY_LENGTH(Ecmd), L" run\"");
+                        wcscat_s(Ecmd, ARRAY_LENGTH(Ecmd), L"\"");
 
                         FreeConsole();
                         STARTUPINFOW si = {0};

--- a/parenttl.h
+++ b/parenttl.h
@@ -39,7 +39,8 @@ bool isParentCmdLine()
                 if ((strcmp(pe32.szExeFile, "cmd.exe") == 0) ||
                 (strcmp(pe32.szExeFile, "powershell.exe") == 0) ||
                 (strcmp(pe32.szExeFile, "wsl.exe") == 0) ||
-                (strcmp(pe32.szExeFile, "wt.exe") == 0) )
+                (strcmp(pe32.szExeFile, "WindowsTerminal.exe") == 0) ||
+                (strcmp(pe32.szExeFile, "winpty-agent.exe") == 0) )
                 {
                     if(procsCnt < PROC_LIST_SIZE)
                     {


### PR DESCRIPTION
This gets rid of the `run` option when launching Launcher.exe from the GUI when Windows/Fluent Terminal is set as the default terminal. Otherwise, it would open in the Windows user directory instead of `~`.

Also fixes the parent process name check to look for `WindowsTerminal.exe` (the actual process name) and `winpty-agent.exe`, which is what Fluent uses, to prevent a bootloop.