### PR TITLE
Added output after successful reset

### DIFF
--- a/main.c
+++ b/main.c
@@ -467,6 +467,10 @@ int main()
             if(SUCCEEDED(hr))
             {
                 hr = WslRegisterDistribution(TargetName,tgzname);
+                if (SUCCEEDED(hr))
+                {
+                    wprintf(L"Reset completed.");
+                }
             }
         }
         else if( WARGV_CMP(1,L"help") | WARGV_CMP(1,L"-h") | WARGV_CMP(1,L"/h") )


### PR DESCRIPTION
The user currently just sees an output of the deinstallation which is not statisfying.
```
PS C:\Users\Joachim> centos reset
This will remove this distro (CentOS) from the filesystem.
Are you sure you would like to proceed? (This cannot be undone)
Type "y" to continue:y
Unregistering...
PS C:\Users\Joachim> centos
[root@DESKTOP-SS5S73V ~]#
```