### PR TITLE
Add autodeploy, improve DEVELOPERS.md, and better expressions for build.bat

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,46 @@
+name: Continuous Deployment
+
+on:
+  push:
+    tags:
+      - '*'
+  
+jobs:
+  publish-github:
+    name: Publish on Github
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cd src
+          env GOOS=windows GOARCH=amd64 go build
+          touch distro.txt
+          for f in ../res/*;do
+            if [ -d "$f" ]; then
+              echo $f >> distro.txt
+            fi
+          done
+          curl -sSfLO https://github.com/akavel/rsrc/releases/download/v0.10.2/rsrc_linux_amd64
+          chmod +x rsrc_linux_amd64
+          cat distro.txt | while read line;do
+            distro="$(echo ${line} | cut -f 3 -d'/')"
+            ./rsrc_linux_amd64 -ico ${line}/icon.ico -o ${distro}.syso
+            env GOOS=windows GOARCH=amd64 go build -o ${distro}.exe
+            rm -rf ${distro}.syso
+          done
+      - name: move wsldl to ../
+        run: mv src/wsldl.exe wsldl.exe
+      - name: Zip package
+        run: cd src;7z a icons.zip *.exe;mv icons.zip ../icons.zip
+      - name: Release body
+        run: echo "![downloads](https://img.shields.io/github/downloads/yuk7/wsldl/${GITHUB_REF}/total?style=flat-square)" > body.txt
+      - name: Upload the release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: body.txt 
+          files: |
+            wsldl.exe
+            icons.zip
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,15 @@ on:
     paths:
       - 'src/**'
       - '.github/workflows/**'
+    tags-ignore:
+      - '*'
   pull_request:
     paths:
       - 'src/**'
       - '.github/workflows/**'
-  
+    tags-ignore:
+      - '*' 
+      
 jobs:
   compile-wsldl-windows:
     name: Compile wsldl

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -5,14 +5,14 @@
 ### Windows
 
 #### Compile using `Go`(Manual build)
-Create wsldl.exe(Manual)
+Create wsldl.exe
 ```cmd
 cd src
 go build
 ```
 
 
-Optionally, to add an icon to exe run:(Manual)
+Optionally, to add an icon to exe run:
 ```cmd
 cd src
 go get github.com/akavel/rsrc

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,23 +1,41 @@
 # Developers Document
 
-## 🛠How to Build
+## 🛠How-to-Build
 
 ### Windows
 
-#### Compile using `Go`
-Create wsldl.exe
-```cmd 
+#### Compile using `Go`(Manual build)
+Create wsldl.exe(Manual)
+```cmd
 cd src
 go build
 ```
 
-Optionally, to add an icon to the exe, create and link a resource with
+
+Optionally, to add an icon to exe run:(Manual)
 ```cmd
 cd src
 go get github.com/akavel/rsrc
 rsrc -ico ../res/%YourDistroName%/icon.ico -o wsldl.syso
 go build
 ```
+
+### Automatic `build.bat` usage
+```
+Usage:
+    <no args>:
+        build single wsldl.exe
+    all:
+        build everything, including exe with icons and default wsldl.exe
+    resources:
+        build only .syso files
+    icons:
+        build exe with icons(must be executed after running resources)
+    clean:
+        clean(remove) .syso files after building exe with icons
+```
+
+
 
 **Note: Creating wsldl.exe for ARM is currently not supported since Go does not support cross-compiling for `windows/arm64`.**
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -24,7 +24,7 @@ go build
 ```
 Usage:
     <no args>:
-        build single wsldl.exe
+        build default wsldl.exe
     all:
         build everything, including exe with icons and default wsldl.exe
     resources:

--- a/build.bat
+++ b/build.bat
@@ -36,7 +36,7 @@ exit /b
 cd /d %~dp0
 mkdir tools >NUL 2>&1
 echo Downloading rsrc...
-curl -sSfLO https://github.com/akavel/rsrc/releases/download/v0.10.2/rsrc_windows_amd64.exe -o tools\rsrc.exe
+curl -sSfL https://github.com/akavel/rsrc/releases/download/v0.10.2/rsrc_windows_amd64.exe -o tools\rsrc.exe
 echo Compiling all resources...
 FOR /D /r %%D in ("res/*") DO (
     tools\rsrc.exe -ico res\%%~nxD\icon.ico -o res\%%~nxD\res.syso

--- a/build.bat
+++ b/build.bat
@@ -6,14 +6,14 @@
 cd /d %~dp0
 
 if "%~1"=="all" (
-    echo Build All
+    echo Building everything
     call :resources
     call :icons
     call :single
     exit /b
 )
 if "%~1"=="resources" (
-    echo Building Resources
+    echo Building resources
     call :resources
     exit /b
 )
@@ -23,7 +23,7 @@ if "%~1"=="icons" (
     exit /b
 )
 if "%~1"=="clean" (
-    echo Clean Files
+    echo Removal of .syso files
     call :clean
     exit /b
 )
@@ -36,8 +36,8 @@ exit /b
 cd /d %~dp0
 mkdir tools >NUL 2>&1
 echo Downloading rsrc...
-curl -sSfL https://github.com/akavel/rsrc/releases/download/v0.10.2/rsrc_windows_amd64.exe -o tools\rsrc.exe
-echo Compiling All Resources...
+curl -sSfLO https://github.com/akavel/rsrc/releases/download/v0.10.2/rsrc_windows_amd64.exe -o tools\rsrc.exe
+echo Compiling all resources...
 FOR /D /r %%D in ("res/*") DO (
     tools\rsrc.exe -ico res\%%~nxD\icon.ico -o res\%%~nxD\res.syso
 )
@@ -45,7 +45,7 @@ exit /b
 
 :icons
 cd /d %~dp0
-echo Building with icons...
+echo Building wsldl with icons...
 mkdir out\icons >NUL 2>&1
 FOR /D /r %%D in ("res/*") DO (
     copy /y res\%%~nxD\res.syso src\res.syso
@@ -61,7 +61,7 @@ exit /b
 cd /d %~dp0
 mkdir out >NUL 2>&1
 cd src
-echo running go build...
+echo Building default wsldl.exe...
 echo go build %GO_BUILD_OPTS% -o "%~dp0\out\wsldl.exe"
 go build %GO_BUILD_OPTS% -o "%~dp0\out\wsldl.exe"
 cd ..


### PR DESCRIPTION
 -  Added a CD script to auto release `wsldl` with the download count badge ***only when you push the tag by `git push --tags`***. 
 - Added instructions for autobuild in `DEVELOPERS.md`
 - `build.bat` had some expression improvements.
 - [Suggestion] How about adding `call :clean` to the `all` option in `build.bat` to clean the `.syso` files after building?