### PR TITLE
Add information about tarball layout to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ If you rename it, you can register with a different name.
 
 
 ## 🔧Install with any rootfs tarball
+
+**Note:**
+The filesystem needs to be in the root of the tarball, some rootfs tarballs may need to be repacked.
+
 #### 1. [Download wsldl.exe](https://github.com/yuk7/wsldl/releases/latest)
 (wsldl.exe is x86_64, wsldl_arm64.exe is ARM64 build)
 #### 2. Rename it for distribution name to register.


### PR DESCRIPTION
When I tried installing Arch using wsldl from the latest official tarball, I received an error about it not being able to mount the filesystem. I found out it was due to the fact that they don't put the root of the filesystem into the root of the tarball (instead it's inside another directory). Repacking it so the layout is correct fixed the problem and it's working fine.

I think providing this information alongside the instructions could be useful.

Technically having the root of the filesystem in a folder called `.` seems to still work (at least for the Alpine rootfs) but I think it's probably the safest to just say it should be in the root since that's how for example the official Ubuntu rootfs is set up.